### PR TITLE
Fix warnings for Elixir 1.17

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/binary.ex
+++ b/lib/binary.ex
@@ -1,6 +1,6 @@
 # http://fileformats.archiveteam.org/wiki/Property_List/Binary
 defmodule Plist.Binary do
-  use Bitwise
+  import Bitwise
 
   @moduledoc false
 
@@ -22,7 +22,7 @@ defmodule Plist.Binary do
 
   defp read_trailer(handle) do
     :file.position(handle, {:eof, -32})
-    trailer = IO.binread(handle, :all)
+    trailer = IO.binread(handle, :eof)
 
     <<
       0::size(48),

--- a/lib/plist.ex
+++ b/lib/plist.ex
@@ -20,7 +20,7 @@ defmodule Plist do
 
   @doc false
   @deprecated "Use decode/1 instead"
-  @since "0.0.6"
+  @doc since: "0.0.6"
   def parse(data) do
     decode(data)
   end

--- a/lib/xml.ex
+++ b/lib/xml.ex
@@ -93,7 +93,8 @@ defmodule Plist.XML do
         |> text_node(:value)
         |> :unicode.characters_to_binary()
 
-      [] -> ""
+      [] ->
+        ""
     end
   end
 
@@ -104,6 +105,6 @@ defmodule Plist.XML do
     do_parse_text_nodes(list, result <> text)
   end
 
-  defp empty?({:xmlText, _, _, [], ' ', :text}), do: true
+  defp empty?({:xmlText, _, _, [], ~c" ", :text}), do: true
   defp empty?(_), do: false
 end


### PR DESCRIPTION
These are hard deprecations and changes which have been out for several versions now so it should be safe to do.